### PR TITLE
[KAIZEN-0] Erstatter gson med jackson

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
     implementation("com.github.seratch:kotliquery:1.8.0")
     implementation("com.natpryce:konfig:1.6.10.0")
     
-    implementation("io.ktor:ktor-serialization-gson:$ktorVersion")
     implementation("com.squareup.okhttp3:mockwebserver:4.4.0")
     implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-apache-jvm:$ktorVersion")

--- a/src/main/kotlin/no/nav/modiapersonoversikt/skrivestotte/service/LeaderElectorService.kt
+++ b/src/main/kotlin/no/nav/modiapersonoversikt/skrivestotte/service/LeaderElectorService.kt
@@ -1,12 +1,12 @@
 package no.nav.modiapersonoversikt.skrivestotte.service
 
-import com.google.gson.Gson
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.engine.apache.Apache
 import io.ktor.client.request.get
+import io.ktor.client.statement.*
 import kotlinx.coroutines.runBlocking
 import no.nav.modiapersonoversikt.config.Configuration
+import no.nav.modiapersonoversikt.utils.fromJson
 import no.nav.modiapersonoversikt.utils.measureTimeMillis
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -14,7 +14,6 @@ import java.lang.Exception
 import java.net.InetAddress
 
 private val client = HttpClient(Apache)
-private val gson = Gson()
 
 private val log: Logger = LoggerFactory.getLogger(LeaderElectorService::class.java)
 data class LeaderElectorResponse(val name: String)
@@ -36,8 +35,8 @@ class LeaderElectorService(val configuration: Configuration) {
     internal fun getLeader(): LeaderElectorResponse {
         return try {
             runBlocking {
-                val response = client.get(configuration.electorPath).body<String>()
-                gson.fromJson(response, LeaderElectorResponse::class.java)
+                val response = client.get(configuration.electorPath)
+                response.bodyAsText().fromJson()
             }
         } catch (e: Exception) {
             log.error("Could not get leader from ${configuration.electorPath}", e)


### PR DESCRIPTION
Ved å erstatte gson med jackson kan vi nå kvitte oss med gson, og på den måten slippe å ha avhengigheter til to serialiserings-bibliotek